### PR TITLE
Related Product / Search Result Card Map

### DIFF
--- a/cvs_client/app/containers/NotFoundPage/index.js
+++ b/cvs_client/app/containers/NotFoundPage/index.js
@@ -6,6 +6,8 @@
 
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import Box from 'grommet/components/Box';
+import CustomHeader from '../../components/CustomHeader';
 
 import H1 from 'components/H1';
 import messages from './messages';
@@ -13,9 +15,12 @@ import messages from './messages';
 export default function NotFound() {
   return (
     <article>
+      <CustomHeader/>
+      <Box align='center' alignContent='center'>
       <H1>
         <FormattedMessage {...messages.header} />
       </H1>
+      </Box>
     </article>
   );
 }

--- a/cvs_client/app/containers/NotFoundPage/index.js
+++ b/cvs_client/app/containers/NotFoundPage/index.js
@@ -15,7 +15,6 @@ import messages from './messages';
 export default function NotFound() {
   return (
     <article>
-      <CustomHeader/>
       <Box align='center' alignContent='center'>
       <H1>
         <FormattedMessage {...messages.header} />

--- a/cvs_client/app/containers/ProductDetail/index.js
+++ b/cvs_client/app/containers/ProductDetail/index.js
@@ -15,6 +15,9 @@ import Heading from 'grommet/components/Heading'
 import Form from 'grommet/components/Form'
 import FormField from 'grommet/components/FormField'
 import TextInput from 'grommet/components/TextInput'
+import Tiles from 'grommet/components/Tiles'
+import Tile from 'grommet/components/Tile'
+import Card from 'grommet/components/Card'
 
 
 const manufacturer = {'CU': 'CU', 'GS': 'GS25', 'SE': 'SEVEN ELEVEN'}
@@ -41,9 +44,23 @@ export class ProductDetail extends React.Component { // eslint-disable-line reac
   }
   render() {
     const productDetail = this.props.productDetail ? this.props.productDetail : ''
-    const relatedProducts = this.props.relatedProducts ? this.props.relatedProducts: []
+    const relatedProducts = this.props.relatedProducts ? this.props.relatedProducts.results: []
     const relatedProductsList = (relatedProducts.filter((obj) => (obj.manufacturer !== productDetail.manufacturer && obj.name !== productDetail.name)).concat(relatedProducts.filter((obj) => (obj.manufacturer === productDetail.manufacturer && obj.name !== productDetail.name))))
     console.log(relatedProductsList)
+
+    var relatedCard;
+    if(relatedProducts == undefined) {
+      relatedCard = (<p>NO RESULT</p>);
+    }
+    else{
+      console.log(relatedProductsList)
+      relatedCard = relatedProducts.map((object, index) => {
+        if(object.id == this.props.params.id) return;
+        else return (<Tile pad='medium' key={index}><Card colorIndex = 'light-1' textSize = 'small' thumbnail = {<Image src={object.image} />} label={object.manufacturer} heading = {object.name} key = {index} onClick={() => this.props.router.push(`/productDetail/${object.id}`)}/></Tile>);
+    })
+  }
+
+
     return (
       <div>
         <div style={{flexDirection: 'row', display: 'flex', padding: '30px'}}>
@@ -68,6 +85,7 @@ export class ProductDetail extends React.Component { // eslint-disable-line reac
         {
           (this.state && this.state.relatedRequestDone || (productDetail !== '' && !(productDetail.small_category || productDetail.large_category))) ? <h3>{relatedProducts.length === 0 ? '인기 상품' : '유사 상품'}</h3> : <div/>
         }
+        <Tiles fill={true}>{relatedCard}</Tiles>
         <Form>
           <FormField label='짧은 상품평'>
             <TextInput/>

--- a/cvs_client/app/containers/ProductDetail/index.js
+++ b/cvs_client/app/containers/ProductDetail/index.js
@@ -56,7 +56,7 @@ export class ProductDetail extends React.Component { // eslint-disable-line reac
       console.log(relatedProductsList)
       relatedCard = relatedProducts.map((object, index) => {
         if(object.id == this.props.params.id) return;
-        else return (<Tile pad='medium' key={index}><Card colorIndex = 'light-1' textSize = 'small' thumbnail = {<Image src={object.image} />} label={object.manufacturer} heading = {object.name} key = {index} onClick={() => this.props.router.push(`/productDetail/${object.id}`)}/></Tile>);
+        else return (<Tile pad='medium' key={index}><Card colorIndex = 'light-1' textSize = 'small' thumbnail = {<Image src={object.image} />} label={object.manufacturer} heading = {object.name} key = {index} onClick={() => {this.props.router.push(`/productDetail/${object.id}`); location.reload();}}/></Tile>);
     })
   }
 

--- a/cvs_client/app/containers/SearchPage/index.js
+++ b/cvs_client/app/containers/SearchPage/index.js
@@ -20,13 +20,16 @@ import Article from 'grommet/components/Article';
 import Section from 'grommet/components/Section';
 import { searchProduct, receivedSearchResult } from './actions';
 import Heading from 'grommet/components/Heading';
-
+import Card from 'grommet/components/Card';
+import Tile from 'grommet/components/Tile';
+import Tiles from 'grommet/components/Tiles';
+import Image from 'grommet/components/Image';
 
 export class SearchPage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props){
     super(props);
 
-    this.state = {term: ''};
+    this.state = {term: '', result: []};
     this.onInputChange = this.onInputChange.bind(this);
     this.onEnter = this.onEnter.bind(this);
   }
@@ -40,6 +43,7 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
       console.log("PARAM: ", this.props.params.id);
       this.props.searchProduct(this.props.params.id);
     }
+
   }
 
   onInputChange(event){
@@ -55,7 +59,15 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
   }
   
   render() {
-    console.log("RESULT: ", this.props.searchResult);
+    var resultCard;
+    if(!this.props.searchResult) {
+      resultCard = (() => {return <p>NO RESULT</p>});
+    }
+    else{
+      resultCard = this.props.searchResult.map((object, index) => {
+      return (<Tile pad='medium' key={index}><Card colorIndex = 'light-1' textSize = 'small' thumbnail = {<Image src={object.image} />} label={object.manufacturer} heading = {object.name} key = {index} onClick={() => this.props.router.push(`/productDetail/${object.id}`)}/></Tile>);
+    })
+  }
 
     return (
       <div>
@@ -78,7 +90,9 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
         </Section>
         </Box>
         </Article>
-
+        <Box colorIndex='light-2'>
+        <Tiles fill={true}>{resultCard}</Tiles>
+        </Box>
       </div>
     );
   }

--- a/cvs_client/app/containers/SearchPage/index.js
+++ b/cvs_client/app/containers/SearchPage/index.js
@@ -60,11 +60,12 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
 
   render() {
     var resultCard;
-    if(!this.props.searchResult) {
-      resultCard = (() => {return <p>NO RESULT</p>});
+    if(this.props.searchResult == undefined) {
+      resultCard = (<p>NO RESULT</p>);
     }
     else{
-      resultCard = this.props.searchResult.map((object, index) => {
+      console.log(this.props.searchResult.results)
+      resultCard = this.props.searchResult.results.map((object, index) => {
       return (<Tile pad='medium' key={index}><Card colorIndex = 'light-1' textSize = 'small' thumbnail = {<Image src={object.image} />} label={object.manufacturer} heading = {object.name} key = {index} onClick={() => this.props.router.push(`/productDetail/${object.id}`)}/></Tile>);
     })
   }


### PR DESCRIPTION
연관상품과 검색결과를 카드로 맵핑함

공통적인 문제점
연관상품과 검색결과가 연관상품 카드를 누르거나 새로운 검색을 했을때 변하지 않는 문제가 있음
-> 페이지 재로딩으로 임시해결

pagination으로 전체상품을 30개씩, 연관상품을 3개씩 보게 할 예정